### PR TITLE
Move bloom filter lookup to device memory

### DIFF
--- a/CudaKeySearchDevice/CudaHashLookup.cu
+++ b/CudaKeySearchDevice/CudaHashLookup.cu
@@ -15,13 +15,13 @@
 
 #define MAX_TARGETS_CONSTANT_MEM 16
 
-__constant__ unsigned int _TARGET_HASH[MAX_TARGETS_CONSTANT_MEM][5];
-__constant__ unsigned int _NUM_TARGET_HASHES[1];
-__constant__ unsigned int *_BLOOM_FILTER[1];
-__constant__ unsigned int _BLOOM_FILTER_MASK[1];
-__constant__ unsigned long long _BLOOM_FILTER_MASK64[1];
+__device__ unsigned int _TARGET_HASH[MAX_TARGETS_CONSTANT_MEM][5];
+__device__ unsigned int _NUM_TARGET_HASHES[1];
+__device__ unsigned int *_BLOOM_FILTER[1];
+__device__ unsigned int _BLOOM_FILTER_MASK[1];
+__device__ unsigned long long _BLOOM_FILTER_MASK64[1];
 
-__constant__ unsigned int _USE_BLOOM_FILTER[1];
+__device__ unsigned int _USE_BLOOM_FILTER[1];
 
 
 static unsigned int swp(unsigned int x)
@@ -45,7 +45,7 @@ static void undoRMD160FinalRound(const unsigned int hIn[5], unsigned int hOut[5]
 }
 
 /**
-Copies the target hashes to constant memory
+Copies the target hashes to device memory
 */
 cudaError_t CudaHashLookup::setTargetConstantMemory(const std::vector<struct hash160> &targets)
 {
@@ -215,7 +215,7 @@ cudaError_t CudaHashLookup::setTargetBloomFilter(const std::vector<struct hash16
 }
 
 /**
-*Copies the target hashes to either constant memory, or the bloom filter depending
+*Copies the target hashes to either device memory, or the bloom filter depending
 on how many targets there are
 */
 cudaError_t CudaHashLookup::setTargets(const std::vector<struct hash160> &targets)


### PR DESCRIPTION
## Summary
- allocate target hashes and bloom filter data in device memory instead of constant memory
- update comments accordingly

## Testing
- `make dir_cudaKeySearchDevice`