### PR TITLE
Add persistent range progress tracking

### DIFF
--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -604,54 +604,128 @@ static void createRangesFile(const std::string &file)
     spec.start = _config.startKey;
     spec.end = _config.endKey;
     spec.size = static_cast<uint64_t>(300ULL * 1000000ULL * 60ULL * 60ULL);
-    spec.next = 0;
 
-    if(!writeRangeSpec(file, spec)) {
+    Logger::log(LogLevel::Debug, "Creating ranges start=" + spec.start.toString() +
+            " end=" + spec.end.toString() + " size=" + util::format(spec.size));
+
+    uint64_t total = computeTotalRanges(spec);
+
+    std::ofstream out(file.c_str(), std::ios::out);
+    if(!out.is_open()) {
         Logger::log(LogLevel::Error, "Unable to write '" + file + "'");
         return;
     }
 
-    Logger::log(LogLevel::Info, "Range descriptor written to '" + file + "'");
+    for(uint64_t i = 0; i < total; i++) {
+        secp256k1::uint256 start;
+        secp256k1::uint256 end;
+        getRange(spec, i, start, end);
+        out << start.toString() << ":" << end.toString() << ":0" << std::endl;
+    }
+
+    out.close();
+    Logger::log(LogLevel::Info, util::format((int)total) + " ranges written to '" + file + "'");
+}
+
+// Divide a 256-bit integer by a 64-bit value and return the quotient as a
+// 64-bit value. The 256-bit value is not expected to exceed 2^192 for this
+// usage and the quotient must fit into 64-bits.
+static uint64_t divUint256ByUint64(secp256k1::uint256 value, uint64_t divisor)
+{
+    __uint128_t rem = 0;
+    secp256k1::uint256 quotient;
+
+    for(int i = 7; i >= 0; i--) {
+        __uint128_t cur = (rem << 32) | value.v[i];
+        quotient.v[i] = (uint32_t)(cur / divisor);
+        rem = cur % divisor;
+    }
+
+    return quotient.toUint64();
+}
+
+static uint64_t computeTotalRanges(const RangeSpec &spec)
+{
+    using secp256k1::uint256;
+
+    uint256 diff = spec.end - spec.start;
+    diff = diff + uint256(1);
+
+    uint256 numerator = diff + uint256(spec.size - 1);
+    return divUint256ByUint64(numerator, spec.size);
 }
 
 static int processRanges(const std::string &file)
 {
-    RangeSpec spec;
-    if(!readRangeSpec(file, spec)) {
+    std::vector<RangeEntry> ranges;
+    if(!loadRanges(file, ranges)) {
         Logger::log(LogLevel::Error, "Unable to read '" + file + "'");
         return 1;
     }
 
-    while(true) {
-        secp256k1::uint256 start;
-        secp256k1::uint256 end;
+    secp256k1::uint256 globalStart = ranges[0].start;
+    secp256k1::uint256 globalEnd = ranges[0].end;
+    size_t processed = 0;
+    for(size_t i = 0; i < ranges.size(); i++) {
+        if(ranges[i].start.cmp(globalStart) < 0) globalStart = ranges[i].start;
+        if(ranges[i].end.cmp(globalEnd) > 0) globalEnd = ranges[i].end;
+        if(ranges[i].done) processed++;
+    }
 
-        getRange(spec, spec.next, start, end);
+    _totalRanges = ranges.size();
+    _rangesRemaining = _totalRanges - processed;
+    _rangeMode = true;
 
-        if(start.cmp(spec.end) > 0) {
-            Logger::log(LogLevel::Info, "All ranges processed");
-            break;
+    Logger::log(LogLevel::Debug, "Loaded " + util::format((int)_totalRanges) + " ranges start=" +
+            globalStart.toString() + " end=" + globalEnd.toString());
+
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+
+    while(processed < _totalRanges) {
+        std::vector<size_t> remaining;
+        remaining.reserve(_totalRanges - processed);
+        for(size_t i = 0; i < ranges.size(); i++) {
+            if(!ranges[i].done) remaining.push_back(i);
         }
 
-        _config.startKey = start;
-        _config.nextKey = start;
-        _config.endKey = end;
+        std::uniform_int_distribution<size_t> dist(0, remaining.size() - 1);
+        size_t idx = remaining[dist(gen)];
+        RangeEntry &r = ranges[idx];
+
+        _currentRangeIdx = idx;
+        _currentRangeEnd = r.end;
+        _rangesRemaining = remaining.size() - 1;
+
+        Logger::log(LogLevel::Debug,
+            "Processing range " + util::format((int)(idx + 1)) + "/" +
+            util::format((int)_totalRanges) + " start=" + r.start.toString() +
+            " end=" + r.end.toString());
+
+        _config.startKey = r.start;
+        _config.nextKey = r.start;
+        _config.endKey = r.end;
         _config.totalkeys = 0;
         _config.elapsed = 0;
 
         int rc = run();
         if(rc != 0) {
+            _rangeMode = false;
             return rc;
         }
 
-        spec.next++;
+        r.done = true;
+        processed++;
 
-        if(!writeRangeSpec(file, spec)) {
+        if(!saveRanges(file, ranges)) {
             Logger::log(LogLevel::Error, "Unable to update '" + file + "'");
+            _rangeMode = false;
             return 1;
         }
     }
 
+    _rangeMode = false;
+    Logger::log(LogLevel::Info, "All ranges processed");
     return 0;
 }
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,22 @@ Use the `-b,` `-t` and `-p` options to specify the number of blocks, threads per
 xxBitCrack.exe -b 32 -t 256 -p 16 1FshYsUh3mqgsG29XpZ23eLjWV8Ur3VwH
 ```
 
+### Range Processing
+
+BitCrack can divide a keyspace into a set of ranges that are processed
+individually. This allows work to be resumed later or shared across machines.
+
+1. Generate a range file with `--create-ranges FILE`. The current keyspace is
+   split into fixed size ranges and written to `FILE`. Each line has the form
+   `START:END:0` where `0` indicates the range has not been processed yet.
+2. Process the ranges using `--process-ranges FILE`. Ranges are selected at
+   random. After a range completes the line is updated to `START:END:1` so it
+   will not be processed again. Progress information shows how many ranges
+   remain.
+
+The range file can be reused in multiple runs and only unfinished ranges will be
+processed.
+
 ### Choosing the right parameters for your device
 
 GPUs have many cores. Work for the cores is divided into blocks. Each block contains threads.


### PR DESCRIPTION
## Summary
- create range files listing start:end pairs
- randomly choose unfinished ranges and mark them done
- show overall progress while processing ranges
- document how to create and process range files

## Testing
- `make`
