### PR TITLE
Fix KeyFinder build errors

### DIFF
--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -605,10 +605,13 @@ static void createRangesFile(const std::string &file)
     spec.end = _config.endKey;
     spec.size = static_cast<uint64_t>(300ULL * 1000000ULL * 60ULL * 60ULL);
 
-    Logger::log(LogLevel::Debug, "Creating range descriptor start=" + spec.start.toString() +
+    Logger::log(LogLevel::Debug, "Creating ranges start=" + spec.start.toString() +
             " end=" + spec.end.toString() + " size=" + util::format(spec.size));
 
-    if(!writeRangeSpec(file, spec)) {
+    uint64_t total = computeTotalRanges(spec);
+
+    std::ofstream out(file.c_str(), std::ios::out);
+    if(!out.is_open()) {
         Logger::log(LogLevel::Error, "Unable to write '" + file + "'");
         return;
     }
@@ -627,58 +630,6 @@ static void createRangesFile(const std::string &file)
 // Divide a 256-bit integer by a 64-bit value and return the quotient as a
 // 64-bit value. The 256-bit value is not expected to exceed 2^192 for this
 // usage and the quotient must fit into 64-bits.
-static uint64_t divUint256ByUint64(secp256k1::uint256 value, uint64_t divisor)
-{
-    __uint128_t rem = 0;
-    secp256k1::uint256 quotient;
-
-    for(int i = 7; i >= 0; i--) {
-        __uint128_t cur = (rem << 32) | value.v[i];
-        quotient.v[i] = (uint32_t)(cur / divisor);
-        rem = cur % divisor;
-    }
-
-    return quotient.toUint64();
-}
-
-static uint64_t computeTotalRanges(const RangeSpec &spec)
-{
-    using secp256k1::uint256;
-
-    uint256 diff = spec.end - spec.start;
-    diff = diff + uint256(1);
-
-    uint256 numerator = diff + uint256(spec.size - 1);
-    return divUint256ByUint64(numerator, spec.size);
-}
-
-// Divide a 256-bit integer by a 64-bit value and return the quotient as a
-// 64-bit value. The 256-bit value is not expected to exceed 2^192 for this
-// usage and the quotient must fit into 64-bits.
-static uint64_t divUint256ByUint64(secp256k1::uint256 value, uint64_t divisor)
-{
-    __uint128_t rem = 0;
-    secp256k1::uint256 quotient;
-
-    for(int i = 7; i >= 0; i--) {
-        __uint128_t cur = (rem << 32) | value.v[i];
-        quotient.v[i] = (uint32_t)(cur / divisor);
-        rem = cur % divisor;
-    }
-
-    return quotient.toUint64();
-}
-
-static uint64_t computeTotalRanges(const RangeSpec &spec)
-{
-    using secp256k1::uint256;
-
-    uint256 diff = spec.end - spec.start;
-    diff = diff + uint256(1);
-
-    uint256 numerator = diff + uint256(spec.size - 1);
-    return divUint256ByUint64(numerator, spec.size);
-}
 
 // Divide a 256-bit integer by a 64-bit value and return the quotient as a
 // 64-bit value. The 256-bit value is not expected to exceed 2^192 for this
@@ -716,40 +667,31 @@ static int processRanges(const std::string &file)
         return 1;
     }
 
-    Logger::log(LogLevel::Debug, "Range spec start=" + spec.start.toString() +
-            " end=" + spec.end.toString() + " size=" + util::format(spec.size));
+    secp256k1::uint256 globalStart = ranges[0].start;
+    secp256k1::uint256 globalEnd = ranges[0].end;
+    size_t processed = 0;
+    for(size_t i = 0; i < ranges.size(); i++) {
+        if(ranges[i].start.cmp(globalStart) < 0) globalStart = ranges[i].start;
+        if(ranges[i].end.cmp(globalEnd) > 0) globalEnd = ranges[i].end;
+        if(ranges[i].done) processed++;
+    }
 
-    _totalRanges = computeTotalRanges(spec);
-    _rangesRemaining = _totalRanges;
+    _totalRanges = ranges.size();
+    _rangesRemaining = _totalRanges - processed;
     _rangeMode = true;
 
-    Logger::log(LogLevel::Debug, "Total ranges computed: " + util::format((int)_totalRanges));
+    Logger::log(LogLevel::Debug, "Loaded " + util::format((int)_totalRanges) + " ranges start=" +
+            globalStart.toString() + " end=" + globalEnd.toString());
 
-    std::vector<bool> done(_totalRanges, false);
     std::random_device rd;
     std::mt19937_64 gen(rd());
-    std::uniform_int_distribution<uint64_t> dist(0, _totalRanges - 1);
 
-    size_t processed = 0;
     while(processed < _totalRanges) {
-        uint64_t idx = dist(gen);
-        while(done[idx]) {
-            idx = dist(gen);
+        std::vector<size_t> remaining;
+        remaining.reserve(_totalRanges - processed);
+        for(size_t i = 0; i < ranges.size(); i++) {
+            if(!ranges[i].done) remaining.push_back(i);
         }
-        done[idx] = true;
-
-        secp256k1::uint256 start;
-        secp256k1::uint256 end;
-        getRange(spec, idx, start, end);
-
-        _currentRangeIdx = idx;
-        _currentRangeEnd = end;
-        _rangesRemaining = _totalRanges - processed - 1;
-
-        Logger::log(LogLevel::Debug,
-            "Processing range " + util::format((int)(idx + 1)) + "/" +
-            util::format((int)_totalRanges) + " start=" + start.toString() +
-            " end=" + end.toString());
 
         std::uniform_int_distribution<size_t> dist(0, remaining.size() - 1);
         size_t idx = remaining[dist(gen)];
@@ -776,8 +718,8 @@ static int processRanges(const std::string &file)
             return rc;
         }
 
+        r.done = true;
         processed++;
-        spec.next = processed;
 
         if(!saveRanges(file, ranges)) {
             Logger::log(LogLevel::Error, "Unable to update '" + file + "'");


### PR DESCRIPTION
## Summary
- fix KeyFinder `createRangesFile` implementation
- remove duplicate helper functions
- restore working `processRanges` implementation

## Testing
- `make BUILD_CUDA=1` *(fails: cuda.h: No such file or directory)*