### PR TITLE
Fix undefined dist variable in KeyFinder

### DIFF
--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -679,6 +679,7 @@ static int processRanges(const std::string &file)
 
     std::random_device rd;
     std::mt19937_64 gen(rd());
+    std::uniform_int_distribution<uint64_t> dist(0, _totalRanges - 1);
 
     while(done.size() < _totalRanges) {
         uint64_t idx = dist(gen);


### PR DESCRIPTION
## Summary
- declare `std::uniform_int_distribution` in `main.cpp` to fix build error

## Testing
- `make dir_keyfinder BUILD_CUDA=1` *(fails: cudaUtil.cpp missing <cuda.h>)*
