### PR TITLE
Ensure random range selection uses /dev/urandom

### DIFF
--- a/KeyFinder/main.cpp
+++ b/KeyFinder/main.cpp
@@ -12,7 +12,6 @@
 #include "CmdParse.h"
 #include "Logger.h"
 #include "ConfigFile.h"
-#include <random>
 #include <cmath>
 #include <stdexcept>
 
@@ -891,14 +890,12 @@ static int processRanges(const std::string &file)
 
     Logger::log(LogLevel::Debug, "Total ranges " + util::format((uint64_t)_totalRanges));
 
-    std::random_device rd;
-    std::mt19937_64 gen(rd());
-    std::uniform_int_distribution<uint64_t> dist(0, _totalRanges - 1);
+    // Use fresh entropy from /dev/urandom (or system RNG) for each range
 
     while(done.size() < _totalRanges) {
-        uint64_t idx = dist(gen);
+        uint64_t idx = util::randomUint64() % _totalRanges;
         while(done.find(idx) != done.end()) {
-            idx = dist(gen);
+            idx = util::randomUint64() % _totalRanges;
         }
 
         secp256k1::uint256 start;

--- a/util/util.h
+++ b/util/util.h
@@ -38,6 +38,8 @@ std::string format(int value);
 void removeNewline(std::string &s);
 unsigned int endian(unsigned int x);
 
+uint64_t randomUint64();
+
 std::string progressBar(double pct, int width);
 
 std::string toLower(const std::string &s);


### PR DESCRIPTION
## Summary
- add util::randomUint64 for cross-platform entropy from /dev/urandom or BCrypt
- use util::randomUint64 in range processing to avoid seeded PRNG

## Testing
- `make dir_clunittest` *(fails: `fatal error: CL/cl.h: No such file or directory`)*